### PR TITLE
fix(libafl): restart client after SIGSEGV

### DIFF
--- a/.github/workflows/smoke_use_libafl.yml
+++ b/.github/workflows/smoke_use_libafl.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Smoke (panic)
         run: bash misc/gosentry/tests/smoke_use_libafl_panic.sh
 
+      - name: Smoke (SIGSEGV restart)
+        run: bash misc/gosentry/tests/smoke_use_libafl_sigsegv_restart.sh
+
       - name: Smoke (overflow)
         run: bash misc/gosentry/tests/smoke_use_libafl_overflow.sh
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Stability note: in LibAFL mode, gosentry forces `GODEBUG=updatemaxprocs=0` (disa
  
 When using LibAFL (default), you must explicitly choose whether to enable git-aware scheduling: `--focus-on-new-code=true|false`. More documentation in [this Markdown file.](misc/gosentry/USE_LIBAFL.md)
 You can also pass an optional JSONC config file for LibAFL (including grammar fuzzing options), see [here.](misc/gosentry/libafl.config.jsonc)
+With `"stop_all_fuzzers_on_panic": false`, LibAFL saves each crash and restarts its client to keep fuzzing.
 
 ```bash
 ./bin/go test -fuzz=FuzzHarness --focus-on-new-code=false --catch-races=false --catch-leaks=false --libafl-config=path/to/libafl.jsonc # optional --libafl-config

--- a/golibafl/Cargo.lock
+++ b/golibafl/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 [[package]]
 name = "build_id2"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "ahash",
  "rustversion",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "core_affinity2"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "libafl_core",
  "libc",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "exceptional"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "libafl_core",
  "libc",
@@ -615,7 +615,7 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 [[package]]
 name = "fast_rands"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "rand_core",
  "rustversion",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "libafl"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "ahash",
  "arbitrary-int 2.0.0",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "libafl_bolts"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "ahash",
  "backtrace",
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "libafl_core"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "backtrace",
  "nix",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "libafl_derive"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "libafl_targets"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "bindgen",
  "cc",
@@ -1026,7 +1026,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "ll_mp"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "exceptional",
  "hostname",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "minibsod"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "exceptional",
  "libc",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "no_std_time"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "rustversion",
 ]
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "nonzero_macros"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 
 [[package]]
 name = "num-conv"
@@ -1275,7 +1275,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 [[package]]
 name = "ownedref"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "libafl_core",
  "rustversion",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "serde_anymap"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "ahash",
  "ctor",
@@ -1659,7 +1659,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "shmem_providers"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "fast_rands",
  "hashbrown",
@@ -1819,7 +1819,7 @@ checksum = "141fb9f71ee586d956d7d6e4d5a9ef8e946061188520140f7591b668841d502e"
 [[package]]
 name = "tuple_list_ex"
 version = "0.16.0"
-source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#942547edc4e6efdedc2391b0a0b5dab36f211708"
+source = "git+https://github.com/kevin-valerio/LibAFL-git-aware?branch=gosentry-libafl-gitaware#5050f0b410f245bb822419419a79273fa080765f"
 dependencies = [
  "libafl_core",
  "ownedref",

--- a/misc/gosentry/USE_LIBAFL.md
+++ b/misc/gosentry/USE_LIBAFL.md
@@ -539,6 +539,7 @@ repro:            golibafl run --input /full/path/to/.../crashes/<id>
 ```
 
 To keep fuzzing after crashes, set `"stop_all_fuzzers_on_panic": false` in the LibAFL JSONC config.
+The crashing client is restarted after target crashes, including `SIGSEGV`.
 
 Note: reproducing may require the same runtime environment variables as fuzzing (e.g. `LD_LIBRARY_PATH` for native deps).
 

--- a/misc/gosentry/tests/smoke_use_libafl.sh
+++ b/misc/gosentry/tests/smoke_use_libafl.sh
@@ -35,6 +35,7 @@ cd "${ROOT_DIR}/src"
 GOROOT_BOOTSTRAP="${bootstrap_goroot}" ./make.bash
 
 bash "${ROOT_DIR}/misc/gosentry/tests/smoke_use_libafl_panic.sh"
+bash "${ROOT_DIR}/misc/gosentry/tests/smoke_use_libafl_sigsegv_restart.sh"
 bash "${ROOT_DIR}/misc/gosentry/tests/smoke_use_libafl_overflow.sh"
 bash "${ROOT_DIR}/misc/gosentry/tests/smoke_use_libafl_multiargs.sh"
 bash "${ROOT_DIR}/misc/gosentry/tests/smoke_use_libafl_multiparams.sh"

--- a/misc/gosentry/tests/smoke_use_libafl_sigsegv_restart.sh
+++ b/misc/gosentry/tests/smoke_use_libafl_sigsegv_restart.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${ROOT_DIR}/misc/gosentry/tests/smoke_use_libafl_common.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+export GOCACHE="${tmp_dir}/gocache"
+
+cfg_path="${tmp_dir}/libafl-config.jsonc"
+cat >"${cfg_path}" <<'EOF'
+{
+  "cores": "0",
+  "stop_all_fuzzers_on_panic": false,
+  "tui_monitor": false,
+  "debug_output": true
+}
+EOF
+
+cd "${ROOT_DIR}/test/gosentry/examples/sigsegv_restart"
+output_file="${tmp_dir}/output.txt"
+set +e
+GOSENTRY_VERBOSE_AFL=1 CGO_ENABLED=1 timeout 10m "${ROOT_DIR}/bin/go" test -fuzz=FuzzSIGSEGV --use-libafl --focus-on-new-code=false --catch-races=false --catch-leaks=false -parallel=1 -fuzztime=2s --libafl-config="${cfg_path}" . 2>&1 | tee "${output_file}"
+status="${PIPESTATUS[0]}"
+set -e
+
+if [[ "${status}" -ne 0 ]]; then
+  echo "expected fuzz run to continue after SIGSEGV, got exit ${status}"
+  exit 1
+fi
+
+if ! grep -Eq "${GOSENTRY_LIBAFL_CRASH_RE}" "${output_file}"; then
+  echo "expected LibAFL to save the SIGSEGV input as a crash"
+  exit 1
+fi
+
+if grep -Fq "The fuzzer crashed inside a crash handler" "${output_file}"; then
+  echo "LibAFL mistook the target SIGSEGV for a crash-handler failure"
+  exit 1
+fi
+
+restart_count="$(grep -Fc "golibafl: client start id=1" "${output_file}" || true)"
+if [[ "${restart_count}" -lt 2 ]]; then
+  echo "expected LibAFL to restart its client after SIGSEGV"
+  exit 1
+fi

--- a/test/gosentry/examples/sigsegv_restart/go.mod
+++ b/test/gosentry/examples/sigsegv_restart/go.mod
@@ -1,0 +1,3 @@
+module sigsegv_restart
+
+go 1.25

--- a/test/gosentry/examples/sigsegv_restart/sigsegv.go
+++ b/test/gosentry/examples/sigsegv_restart/sigsegv.go
@@ -1,0 +1,14 @@
+package sigsegvrestart
+
+/*
+#include <signal.h>
+
+static void trigger_sigsegv(void) {
+	raise(SIGSEGV);
+}
+*/
+import "C"
+
+func triggerSIGSEGV() {
+	C.trigger_sigsegv()
+}

--- a/test/gosentry/examples/sigsegv_restart/sigsegv_test.go
+++ b/test/gosentry/examples/sigsegv_restart/sigsegv_test.go
@@ -1,0 +1,17 @@
+package sigsegvrestart
+
+import (
+	"bytes"
+	"testing"
+)
+
+var sigsegvInput = []byte("SIGSEGV")
+
+func FuzzSIGSEGV(f *testing.F) {
+	f.Add(sigsegvInput)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if bytes.Equal(data, sigsegvInput) {
+			triggerSIGSEGV()
+		}
+	})
+}


### PR DESCRIPTION
Fixes #149 by updating the LibAFL fork's signal-recursion exit check and adding a SIGSEGV restart regression test.