### PR TITLE
fix(ci): bump bootstrap Go to 1.26.5

### DIFF
--- a/.github/workflows/catch_hangs.yml
+++ b/.github/workflows/catch_hangs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go (bootstrap)
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.5"
 
       - name: Export GOROOT_BOOTSTRAP
         run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/catch_leaks.yml
+++ b/.github/workflows/catch_leaks.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go (bootstrap)
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.5"
 
       - name: Export GOROOT_BOOTSTRAP
         run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/catch_races.yml
+++ b/.github/workflows/catch_races.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go (bootstrap)
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.5"
 
       - name: Export GOROOT_BOOTSTRAP
         run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go (bootstrap)
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.5'
+        go-version: '1.26.5'
 
     - name: Export GOROOT_BOOTSTRAP
       run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> $GITHUB_ENV
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Go (bootstrap)
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.5'
+        go-version: '1.26.5'
 
     - name: Export GOROOT_BOOTSTRAP
       run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> $GITHUB_ENV

--- a/.github/workflows/smoke_use_libafl.yml
+++ b/.github/workflows/smoke_use_libafl.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go (bootstrap)
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.5"
 
       - name: Export GOROOT_BOOTSTRAP
         run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> "$GITHUB_ENV"
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go (bootstrap)
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26.5"
 
       - name: Export GOROOT_BOOTSTRAP
         run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> "$GITHUB_ENV"

--- a/misc/gosentry/scripts/quickcheck.sh
+++ b/misc/gosentry/scripts/quickcheck.sh
@@ -8,7 +8,7 @@ if [[ -z "${bootstrap_goroot}" ]]; then
   if command -v go >/dev/null 2>&1; then
     bootstrap_goroot="$(go env GOROOT)"
   else
-    bootstrap_ver="go1.25.5"
+    bootstrap_ver="go1.26.5"
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     arch="$(uname -m)"
     case "${arch}" in

--- a/misc/gosentry/tests/smoke_use_libafl.sh
+++ b/misc/gosentry/tests/smoke_use_libafl.sh
@@ -8,7 +8,7 @@ if [[ -z "${bootstrap_goroot}" ]]; then
   if command -v go >/dev/null 2>&1; then
     bootstrap_goroot="$(go env GOROOT)"
   else
-    bootstrap_ver="go1.25.5"
+    bootstrap_ver="go1.26.5"
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     arch="$(uname -m)"
     case "${arch}" in


### PR DESCRIPTION
Upstream commit c88c8c00e1 raised the minimum bootstrap toolchain to Go 1.26.0. CI still pinned 1.25.5, so make.bash failed right away with "found packages main (build.go) and
building_Go_requires_Go_1_26_0_or_later (notgo126.go) in src/cmd/dist".

All five workflows that build the toolchain have been red since the upstream merge in #165. Repo knowledge and CodeQL stayed green because they never run make.bash.

Also bumps the go1.25.5 fallback download in quickcheck.sh and smoke_use_libafl.sh, which carried the same stale pin.

**Summary**
- 

**Checklist**
- [x] Ran `bash misc/gosentry/scripts/quickcheck.sh`
- [x] If fuzz plumbing changed: ran `bash misc/gosentry/tests/smoke_use_libafl.sh` (or a narrower smoke script)
- [ ] If LibAFL `go test` flags changed: updated `misc/gosentry/USE_LIBAFL.md`
- [ ] If user-visible behavior changed: updated `README.md`
- [ ] If internal wiring/workflows changed: updated `docs/gosentry/*` (start at `docs/gosentry/index.md`)
